### PR TITLE
Fix calling languages without passing options

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@ module.exports = {
 		this.languages = function (opt, callback) {
 			var req, request_options;
 			if (typeof opt === 'function') {
-				if (callback === null) {
+				if (callback === undefined) {
 					callback = opt;
 				}
 				opt = {


### PR DESCRIPTION
This fixes the `languages` function when no options are passed, only a callback (as is shown in the readme).
If the second argument is not passed, its value is `undefined`, not `null`.
