### PR TITLE
Don't try to create the output file if we received a 404

### DIFF
--- a/index.js
+++ b/index.js
@@ -559,6 +559,8 @@ module.exports = {
 								language: langIso
 							});
 							req = httpsClient.get(request_options, function (res) {
+								var skip = false;
+
 								gutil.log(chalk.white('Downloading file: ') +
 									chalk.blue(path.basename(file.path)));
 
@@ -569,8 +571,7 @@ module.exports = {
 											gutil.log(chalk.red('✘ ') +
 												chalk.blue(request_options.path) +
 												chalk.white('Does not exist'));
-											buffer.push(file);
-											return callback();
+											skip = true;
 										} else {
 											res.emit('error', new gutil.PluginError({
 												plugin: 'gulp-transifex',
@@ -589,6 +590,11 @@ module.exports = {
 
 								res.on('end', function () {
 									var data;
+
+									if (skip) {
+										buffer.push(file);
+										return callback();
+									}
 
 									gutil.log(chalk.green('✔ ') +
 										chalk.blue(langIso, path.basename(file.path)) +


### PR DESCRIPTION
Before this fix the gulp-transifex plugin would still produce an empty file in the 404 case, now the file is skipped -- which is what the code looked like it wanted to do.
