### PR TITLE
Make it possible to adjust the name of the resource for pullResource and pushResource

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,29 @@ module.exports = {
 			});
 		};
 
+		this.resourceName = function(file) {
+			if (typeof options.resource_name === 'function') {
+				return options.resource_name(file);
+			} else {
+				return path.basename(file.path).replace(/\./, '');
+			}
+		};
+
+		this.targetName = function(file, langIso) {
+			if (typeof options.target_name === 'function') {
+				return options.target_name(file, langIso);
+			} else {
+				const ext_name = path.extname(file.path);
+				const file_name = path.basename(file.path, ext_name);
+
+				if (ext_name === '.pot') {
+					ext_name = '.po';
+				}
+
+				return file_name + ext_name;
+			}
+		};
+
 		this.resourceAttributes = function (resource, callback) {
 			var req, attrs = '';
 			req = request('GET', _this._paths.get_resource({
@@ -107,7 +130,7 @@ module.exports = {
 					remoteDate = '',
 					newFile = false;
 
-			resource = path.basename(file.path).replace(/\./,'');
+			resource = _this.resourceName(file);
 			async.series([
 				function (cb) {
 					_this.resourceAttributes(resource, function (data) {
@@ -262,7 +285,7 @@ module.exports = {
 									port: '443',
 									path: _this._paths.update_resource({
 										project: options.project,
-										resource: path.basename(file.path).replace(/\./,'')
+										resource: _this.resourceName(file)
 									}),
 									method: 'PUT',
 									auth: options.user + ':' + options.password,
@@ -291,8 +314,7 @@ module.exports = {
 													.toString('utf8'),
 												name: path.basename(file.path)
 													.replace(path.extname(file.path), ''),
-												slug: path.basename(file.path)
-													.replace(/\./,''),
+												slug: _this.resourceName(file),
 												i18n_type: options.i18n_type
 											};
 											data = JSON.stringify(data);
@@ -433,7 +455,7 @@ module.exports = {
 					data = {
 						content: file.contents.toString('utf8'),
 						name: path.basename(file.path),
-						slug: path.basename(file.path).replace(path.extname(file.path)),
+						slug: _this.resourceName(file.path),
 						i18n_type: options.i18n_type
 					};
 					data = JSON.stringify(data);
@@ -555,7 +577,7 @@ module.exports = {
 							}
 
 							request_options.path = _this._paths.get_or_create_translation({
-								resource: path.basename(file.path).replace(/\./, ''),
+								resource: _this.resourceName(file),
 								language: langIso
 							});
 							req = httpsClient.get(request_options, function (res) {
@@ -588,7 +610,18 @@ module.exports = {
 								});
 
 								res.on('end', function () {
-									var data;
+									var data, target;
+
+									target = path.resolve(local_path, _this.targetName(file, langIso));
+									if (!fs.existsSync(path.dirname(target))) {
+										mkdirp.sync(path.dirname(target));
+									}
+									output = fs.createWriteStream(target);
+
+									output.on('finish', function () {
+										buffer.push(file);
+										return callback();
+									});
 
 									gutil.log(chalk.green('✔ ') +
 										chalk.blue(langIso, path.basename(file.path)) +
@@ -606,30 +639,7 @@ module.exports = {
 										}));
 										output.end();
 									}
-
 								});
-							});
-
-							local_path	= path.resolve(local_path);
-							ext_name	= path.extname(file.path);
-							file_name	= path.basename(file.path, ext_name);
-
-
-							if (ext_name === '.pot') {
-								ext_name = '.po';
-							}
-
-							file_name = local_path + '/' + file_name + ext_name;
-
-							if (!fs.existsSync(local_path)) {
-								mkdirp.sync(local_path);
-							}
-
-							output = fs.createWriteStream(file_name);
-
-							output.on('finish', function () {
-								buffer.push(file);
-								callback();
 							});
 
 							req.on('error', function (err) {
@@ -641,14 +651,11 @@ module.exports = {
 							cb();
 						})
 					});
-
 				}
-
 			}, function (cb) {
 				if (callback) {
 					callback();
 				}
-				gutil.log('File saved');
 				cb();
 			});
 			return buffer;


### PR DESCRIPTION
Previously the plugin would use the filename with extension and with all '.' characters
removed as a resource name, now one can optionally provide a 'resource_name' function
via the global options argument. This function is invoked with the Vinyl object as single
parameter.
Similarly, a 'target_name' function can be provided to adjust the default output path
for files produced with 'pullResource'.
## 

Use case for us: we're using XLIFF files, and name them according to a specific schema (basically the name of the resource is _inside_ the xliff file). This commit makes it possible to implement that name/file mapping scheme for us in a very concise way.
