### PR TITLE
Allow to specify translation mode query param when pulling translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ var options = {
         <ISO 639-1 language code>: <custom language code>
     },
     use_custom_language_codes: <Boolean>,
-    language_codes_as_objects: <Boolean>
+    language_codes_as_objects: <Boolean>,
+    translation_mode: <String optional. See 'https://docs.transifex.com/api/translations#downloading-and-uploading-translations'>
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -557,7 +557,8 @@ module.exports = {
 
 							request_options.path = _this._paths.get_or_create_translation({
 								resource: path.basename(file.path).replace(/\./g, ''),
-								language: langIso
+								language: langIso,
+                                translation_mode: options.translation_mode,
 							});
 							req = httpsClient.get(request_options, function (res) {
 								gutil.log(chalk.white('Downloading file: ') +

--- a/libs/paths.js
+++ b/libs/paths.js
@@ -22,9 +22,15 @@ module.exports = function(options) {
       });
     },
     get_or_create_translation: function(vars) {
-      return sprintf(this.base_path + '%(project)s/resource/%(resource)s/translation/%(language)s/', util._extend({
-        project: options.project
+      var path = sprintf(this.base_path + '%(project)s/resource/%(resource)s/translation/%(language)s/', util._extend({
+        project: options.project,
       }, vars));
+
+      if (vars.translation_mode) {
+        path += '?mode=' + vars.translation_mode;
+      }
+
+      return path;
     },
     local_translations_path: function(vars) {
       return sprintf('%(local_path)s/%(language)s/', util._extend({


### PR DESCRIPTION
This can be useful when dealing with empty translations for files that are invalid when translation is listed but empty. For example, XLIFF `<target>` element should always contain something or the translation shouldn't be listed at all. Transifex API always seems to send the translation even when it's empty (with `<target>` missing completely) and as a workaround `?mode=sourceastranslation` can be used to avoid blank translations. If specified, `<target>` will be present holding original source text.